### PR TITLE
Update path for schema

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -73,7 +73,7 @@
         "editor.snippetSuggestions": "top",
         "xml.validation.enabled": true,
         "pretext-tools.schema.versionName": "Custom",
-        "pretext-tools.schema.customPath": "/workspaces/library/schema/tbil.rng",
+        "pretext-tools.schema.customPath": "/workspaces/brown-tbil/schema/tbil.rng",
         "redhat.telemetry.enabled": false,
         "CodeChat.CodeChatServer.Command": "CodeChat_Server",
         "files.eol": "\n"


### PR DESCRIPTION
I ran into one problem with pretext-tools plugin, which was a result of your renaming your fork and a path being hard-coded using the original repo name.

This PR targets your Spring2025 branch.  Accept this and rebuild your repo and hopefully the vscode issues will go away.  Making changes like this on other branches will also be required.